### PR TITLE
Skip newlines

### DIFF
--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -14,7 +14,7 @@ class PrometheusParser
     s = StringScanner.new(raw)
     res = []
     until s.eos?
-      if s.peek(1) == "#" # Skip comment lines
+      if s.peek(1) == "#" || s.peek(1) == "\n" # Skip comment and empty lines
         s.scan(/.*\n/)
         next
       end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -167,4 +167,17 @@ describe PrometheusParser do
     _(res.first[:attrs][:content_type]).must_equal "text/plain; version=0.0.4"
     _(res.first[:value]).must_equal 200
   end
+
+  it "should handle extra newlines" do
+    raw = <<~METRICS
+
+      response_packet_get_children_cache_hits{version="1.0.0"} 0.0
+
+    METRICS
+    res = PrometheusParser.parse(raw)
+    _(res.size).must_equal 1
+    _(res.first[:key]).must_equal "response_packet_get_children_cache_hits"
+    _(res.first[:value]).must_equal 0.0
+    _(res.first[:attrs]).must_equal({ version: "1.0.0" })
+  end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Got prometheus metrics with extra newlines at the end, which our parser choked on.

### WHAT is this pull request doing?

Skipping newlines.

### HOW can this pull request be tested?

`rake`