### PR TITLE
Support parsing of less than and more than characters

### DIFF
--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -8,7 +8,7 @@ class PrometheusParser
   KEY_RE = /[\w:]+/
   VALUE_RE = /-?\d+\.?\d*E?-?\d*|NaN/
   ATTR_KEY_RE = /[ \w-]+/
-  ATTR_VALUE_RE = %r{\s*"([\\"'\sa-zA-Z0-9\-_/.+~@;=]*)"\s*} # /\s*"(\S*)"\s*/
+  ATTR_VALUE_RE = %r{\s*"([\\"'\sa-zA-Z0-9\-_/.+~@;=<>]*)"\s*} # /\s*"(\S*)"\s*/
 
   def self.parse(raw)
     s = StringScanner.new(raw)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -168,6 +168,17 @@ describe PrometheusParser do
     _(res.first[:value]).must_equal 200
   end
 
+  it "should handle less than (<) and more than (>) values in attributes" do
+    raw = <<~METRICS
+
+      rabbitmq_detailed_connection_channels{channel="<0.9648.14>"} 0
+
+    METRICS
+    res = PrometheusParser.parse(raw)
+    _(res.first[:attrs][:channel]).must_equal "<0.9648.14>"
+    _(res.first[:value]).must_equal 0
+  end
+
   it "should handle extra newlines" do
     raw = <<~METRICS
 


### PR DESCRIPTION
### WHY are these changes introduced?

Values from rmq prometheus metrics can include less than (<) and more than (>) characters.  

### WHAT is this pull request doing?

Adds support for the characters to the parser regex. 

### HOW can this pull request be tested?

rake test

---

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)
