### PR TITLE
Skip metric when invalid attr value

### DIFF
--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -20,7 +20,12 @@ class PrometheusParser
       end
       key = s.scan KEY_RE
       raise Invalid unless key
-      attrs = parse_attrs(s)
+      begin
+        attrs = parse_attrs(s)
+      rescue Invalid
+        s.scan(/.*\n/)
+        next
+      end
       value = s.scan VALUE_RE
       raise Invalid unless value
       value = value.to_f

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -181,4 +181,16 @@ describe PrometheusParser do
     _(res.first[:value]).must_equal 0.0
     _(res.first[:attrs]).must_equal({ version: "1.0.0" })
   end
+
+  it "should skip quoted values in attributes" do
+    raw = <<~METRICS
+      rabbitmq_detailed_queue_messages_ready{vhost="xxxxxxxx",queue="F56211164662"} 0
+      rabbitmq_detailed_queue_messages_ready{vhost="xxxxxxxx",queue=""{"command":"OPEN"}""} 5
+      rabbitmq_detailed_queue_messages_ready{vhost="xxxxxxxx",queue="F55211161384"} 0
+    METRICS
+    res = PrometheusParser.parse(raw)
+    _(res.first[:attrs][:queue]).must_equal "F56211164662"
+    _(res.last[:attrs][:queue]).must_equal "F55211161384"
+    _(res.size).must_equal 2
+  end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Queue name in prod had quotes in name, this is a bug in rmq (`promtool check metrics` => `error while linting: text format parsing error in line 2199: unexpected end of label value ""`). So solution could be to skip these metrics for now

### WHAT is this pull request doing?

Skips metric which includes invalid attribute values. 

### HOW can this pull request be tested?

rake test

---

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)
