### PR TITLE
Handle value "unknown" which is invalid

### DIFF
--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -6,7 +6,7 @@ class PrometheusParser
   end
 
   KEY_RE = /[\w:]+/
-  VALUE_RE = /-?\d+\.?\d*E?-?\d*|NaN/
+  VALUE_RE = /-?\d+\.?\d*E?-?\d*|NaN|unknown/
   ATTR_KEY_RE = /[ \w-]+/
   ATTR_VALUE_RE = /\s*"([^"\\]*(\\.[^"\\]*)*)"\s*/ # /\s*"(\S*)"\s*/
 
@@ -27,6 +27,9 @@ class PrometheusParser
         next
       end
       value = s.scan VALUE_RE
+      # Workaround for faulty RabbitMQ metrics exporter
+      # https://github.com/rabbitmq/rabbitmq-server/discussions/5143
+      value = "NaN" if value == "unknown"
       raise Invalid unless value
       value = value.to_f
       s.scan(/\n/)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -193,4 +193,15 @@ describe PrometheusParser do
     _(res.last[:attrs][:queue]).must_equal "F55211161384"
     _(res.size).must_equal 2
   end
+
+  # Some RabbitMQ versions can respond with "unknown"
+  # https://github.com/rabbitmq/rabbitmq-server/discussions/5143
+  it "should fix broken values from RabbitMQ (unknown -> NaN)" do
+    raw = <<~METRICS
+      rabbitmq_detailed_disk_space_available_bytes unknown
+    METRICS
+    res = PrometheusParser.parse(raw)
+    _(res.first[:key]).must_equal "rabbitmq_detailed_disk_space_available_bytes"
+    _(res.first[:value]).must_equal 0.0
+  end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Some RabbitMQ versions can respond with "unknown" https://github.com/rabbitmq/rabbitmq-server/discussions/5143
This is not valid Prometheus syntax and will cause the parser to raise `Invalid` exceptions.

### WHAT is this pull request doing?

Instead of giving up we'll rewrite to NaN wich is valid Prometheus syntax.

### HOW can this pull request be tested?

`rake` to run specs.

<!---

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
