### PR TITLE
Add missing `strscan` require

### DIFF
--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -1,3 +1,5 @@
+require "strscan"
+
 class PrometheusParser
   class Invalid < StandardError
     def initialize


### PR DESCRIPTION
Tests passed because it was implicitly required by the simplecov gem.

https://docs.ruby-lang.org/en/master/StringScanner.html