### PR TITLE
Don't parse NaN value into float since that results in 0.0

### DIFF
--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -31,9 +31,9 @@ class PrometheusParser
       value = s.scan VALUE_RE
       # Workaround for faulty RabbitMQ metrics exporter
       # https://github.com/rabbitmq/rabbitmq-server/discussions/5143
-      value = Float::NAN if ["unknown", "NaN"].include?(value)
+      value = Float::NAN if %w[unknown NaN].include?(value)
       raise Invalid unless value
-      value = value.to_f unless value == "NaN"
+      value = value.to_f
       s.scan(/\n/)
       res.push({ key:, attrs:, value: })
     end

--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -33,7 +33,7 @@ class PrometheusParser
       # https://github.com/rabbitmq/rabbitmq-server/discussions/5143
       value = "NaN" if value == "unknown"
       raise Invalid unless value
-      value = value.to_f
+      value = value.to_f unless value == "NaN"
       s.scan(/\n/)
       res.push({ key:, attrs:, value: })
     end

--- a/lib/prometheus_parser.rb
+++ b/lib/prometheus_parser.rb
@@ -31,7 +31,7 @@ class PrometheusParser
       value = s.scan VALUE_RE
       # Workaround for faulty RabbitMQ metrics exporter
       # https://github.com/rabbitmq/rabbitmq-server/discussions/5143
-      value = "NaN" if value == "unknown"
+      value = Float::NAN if ["unknown", "NaN"].include?(value)
       raise Invalid unless value
       value = value.to_f unless value == "NaN"
       s.scan(/\n/)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -86,7 +86,7 @@ describe PrometheusParser do
       kafka_server_socket_server_metrics NaN
     METRICS
     res = PrometheusParser.parse(raw)
-    _(res.first[:value]).must_equal 0.0
+    _(res.first[:value]).must_equal "NaN"
   end
 
   it "should handle 8.123213E-28" do
@@ -103,7 +103,7 @@ describe PrometheusParser do
     METRICS
     res = PrometheusParser.parse(raw)
     _(res.first[:attrs][:quantile]).must_equal "0.5"
-    _(res.first[:value]).must_equal 0
+    _(res.first[:value]).must_equal "NaN"
   end
 
   it "should handle space values in attributes" do
@@ -202,6 +202,6 @@ describe PrometheusParser do
     METRICS
     res = PrometheusParser.parse(raw)
     _(res.first[:key]).must_equal "rabbitmq_detailed_disk_space_available_bytes"
-    _(res.first[:value]).must_equal 0.0
+    _(res.first[:value]).must_equal "NaN"
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -86,7 +86,7 @@ describe PrometheusParser do
       kafka_server_socket_server_metrics NaN
     METRICS
     res = PrometheusParser.parse(raw)
-    _(res.first[:value]).must_equal "NaN"
+    _(res.first[:value]).must_be_same_as Float::NAN
   end
 
   it "should handle 8.123213E-28" do
@@ -103,7 +103,7 @@ describe PrometheusParser do
     METRICS
     res = PrometheusParser.parse(raw)
     _(res.first[:attrs][:quantile]).must_equal "0.5"
-    _(res.first[:value]).must_equal "NaN"
+    _(res.first[:value]).must_be_same_as Float::NAN
   end
 
   it "should handle space values in attributes" do
@@ -202,6 +202,6 @@ describe PrometheusParser do
     METRICS
     res = PrometheusParser.parse(raw)
     _(res.first[:key]).must_equal "rabbitmq_detailed_disk_space_available_bytes"
-    _(res.first[:value]).must_equal "NaN"
+    _(res.first[:value]).must_be_same_as Float::NAN
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Don't parse NaN value into float since that parses the value into 0.0 which can mess up alarms when we have that in place. Better to keep the value as NaN and explicitly handle that case. [Trello](https://trello.com/c/R9q33N09)

### WHAT is this pull request doing?

Leave NaN value as NaN. 

### HOW can this pull request be tested?

rake test

<!---

Friendly reminders

- Include reference to Trello (or possibly Slack)
- Include changelog to support if applicable
- Lint rules pass
- The environment (`heroku config`) has been updated if needed (new `ENV` variables)

-->
